### PR TITLE
Adopt to large scale testing

### DIFF
--- a/egressip.yaml
+++ b/egressip.yaml
@@ -1,0 +1,14 @@
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: egressip-test
+spec:
+  egressIPs:
+    - 192.168.0.145
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: test
+  podSelector:
+    matchLabels:
+      app: validator 
+

--- a/egressip/deployment-client.yml
+++ b/egressip/deployment-client.yml
@@ -1,0 +1,67 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: client-{{.Replica}}-{{.Iteration}}
+spec:
+  replicas: {{.podReplicas}}
+  selector:
+    matchLabels:
+      name: client-{{.Replica}}-{{.Iteration}}
+  template:
+    metadata:
+      labels:
+        name: client-{{.Replica}}-{{.Iteration}}
+        app: client
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: client
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/workload
+                operator: DoesNotExist
+      containers:
+      - name: client-app
+        image: quay.io/vkommadi/eip-checker:latest
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "10m"
+        ports:
+        - containerPort: 8080
+          name: metrics
+        env:
+        - name: EXT_SERVER_HOST
+          value: "192.168.0.155"
+        - name: EXT_SERVER_PORT
+          value: "{{ add 9002 (mod .Iteration 60) }}"
+        - name: EGRESS_IPS
+            {{- $eips := (splitList " " (GetIPAddress .eipAddresses .Iteration .addrPerIteration) | join ",") }}
+          value: "{{$eips}}"
+        - name: DELAY_BETWEEN_START_REQ_SEC 
+          value: "1"
+        - name: REQ_START_TIMEOUT_SEC
+          value: "1"
+        - name: DELAY_BETWEEN_REQ_SEC
+          value: "10"
+        - name: REQ_TIMEOUT_SEC
+          value: "5"
+        imagePullPolicy: Always
+        securityContext:
+          privileged: false
+        volumeMounts:
+      restartPolicy: Always
+  strategy:
+    type: RollingUpdate
+

--- a/egressip/deployment-client.yml
+++ b/egressip/deployment-client.yml
@@ -44,20 +44,20 @@ spec:
         env:
         - name: EXT_SERVER_HOST
           value: "192.168.0.155"
-        - name: EXT_SERVER_PORT
-          value: "{{ add 9002 (mod .Iteration 60) }}"
+        - name: EXT_SERVER_PORTS
+          value: "9002:9061"
         - name: EGRESS_IPS
             {{- $eips := (splitList " " (GetIPAddress .eipAddresses .Iteration .addrPerIteration) | join ",") }}
           value: "{{$eips}}"
         - name: DELAY_BETWEEN_START_REQ_SEC 
           value: "1"
         - name: REQ_START_TIMEOUT_SEC
-          value: "1"
+          value: "0"
         - name: DELAY_BETWEEN_REQ_SEC
-          value: "10"
+          value: "0"
         - name: REQ_TIMEOUT_SEC
-          value: "5"
-        imagePullPolicy: Always
+          value: "1"
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false
         volumeMounts:

--- a/egressip/egressip-obj.yml
+++ b/egressip/egressip-obj.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: egressip-obj-{{.Iteration}}
+spec:
+  egressIPs:
+  {{range (splitList " " (GetIPAddress .eipAddresses .Iteration .addrPerIteration))}}
+  - {{.}}
+  {{end}}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: egressip-{{.Iteration}}
+  podSelector:
+    matchLabels:
+      app: client

--- a/egressip/egressip.yml
+++ b/egressip/egressip.yml
@@ -1,0 +1,68 @@
+---
+global:
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  indexerConfig:
+    esServers: ["{{.ES_SERVER}}"]
+    insecureSkipVerify: true
+    defaultIndex: {{.ES_INDEX}}
+    type: {{.INDEXING_TYPE}}
+  measurements:
+    - name: podLatency
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: {{.POD_READY_THRESHOLD}}
+{{ if eq .SVC_LATENCY "true" }}
+    - name: serviceLatency
+      svcTimeout: 10s
+{{ end }}
+jobs:
+  - name: egressip
+    namespace: egressip
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: false
+    preLoadPeriod: 15s
+    churn: {{.CHURN}}
+    churnCycles: {{.CHURN_CYCLES}}
+    churnDuration: {{.CHURN_DURATION}}
+    churnPercent: {{.CHURN_PERCENT}}
+    churnDelay: {{.CHURN_DELAY}}
+    churnDeletionStrategy: {{.CHURN_DELETION_STRATEGY}}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+      openshift.io/cluster-monitoring: true
+    objects:
+
+      - objectTemplate: prometheus_role.yml
+        replicas: 1
+
+      - objectTemplate: prometheus_role_binding.yml
+        replicas: 1
+      
+      - objectTemplate: pod_monitor.yml
+        replicas: 1
+
+      - objectTemplate: egressip-obj.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 2
+          eipAddresses: {{.EIP_ADDRESSES}}
+          addrPerIteration: 2
+          
+      - objectTemplate: deployment-client.yml
+        replicas: 1
+        inputVars:
+          podReplicas: 2
+          eipAddresses: {{.EIP_ADDRESSES}}
+          addrPerIteration: {{.ADDRESSES_PER_ITERATION}}
+
+

--- a/egressip/pod_monitor.yml
+++ b/egressip/pod_monitor.yml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: pod-monitor-{{.Replica}}
+spec:
+  selector:
+    matchLabels:
+      app: client
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    scheme: http

--- a/egressip/prometheus_role.yml
+++ b/egressip/prometheus_role.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/egressip/prometheus_role_binding.yml
+++ b/egressip/prometheus_role_binding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/pod.yaml
+++ b/pod.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: eip-monitor
-  namespace: monitor-eip
+  namespace: test
   labels:
     app: validator
 spec:
@@ -17,19 +17,23 @@ spec:
       capabilities:
         drop:
           - ALL
-    image: quay.io/mkennell/eip-checker:latest
+    image: quay.io/vkommadi/eip-checker:latest
     imagePullPolicy: Always
     env:
     - name: EXT_SERVER_HOST
-      value: "1.1.1.1"
+      value: "192.168.0.155"
     - name: EXT_SERVER_PORT
-      value: "80"
+      value: "9002"
     - name: EGRESS_IPS
-      value: "2.2.2.2,3.3.3.3"
-    - name: DELAY_BETWEEN_REQ_SEC
-      value: "2"
-    - name: REQ_TIMEOUT_SEC
+      value: "192.168.0.145"
+    - name: DELAY_BETWEEN_START_REQ_SEC 
       value: "1"
+    - name: REQ_START_TIMEOUT_SEC
+      value: "1"
+    - name: DELAY_BETWEEN_REQ_SEC
+      value: "10"
+    - name: REQ_TIMEOUT_SEC
+      value: "5"
     - name: POD_NAME
       valueFrom:
         fieldRef:
@@ -40,6 +44,7 @@ spec:
           fieldPath: metadata.namespace
     ports:
     - containerPort: 8080
+      name: metrics
     resources:
       requests:
         cpu: "50m"

--- a/pod_monitor.yaml
+++ b/pod_monitor.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: eip-validator
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app: validator
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 15s
+    scheme: http
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: test
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+    


### PR DESCRIPTION
Some enhancements according to our scale testing requirements

- Fix checking of http status code
- Use PodMonitor instead of ServiceMonitor
- Removed adding a new label for each namespace
- Add eip_recovery_latency and startup_non_eip_total metrics
- Use random dest port for request